### PR TITLE
fix: update login button selector in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -368,7 +368,7 @@ func login(ctx context.Context, email, password string, navigateToTimeline bool)
 	defer loginCancel()
 
 	actions := []chromedp.Action{
-		chromedp.Evaluate(`document.querySelector('button[type="submit"]').click()`, nil),
+		chromedp.Evaluate(`document.evaluate("//button[span[text()='ログイン']]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.click()`, nil),
 		// サーバーからの応答とリダイレクトを待つために少し待機
 		chromedp.Sleep(10 * time.Second),
 	}


### PR DESCRIPTION
The original `button[type="submit"]` selector was failing due to changes in the YAMAP login page DOM. This commit replaces it with an XPath selector that finds the button by its text content ('ログイン'), ensuring the crawler can successfully log in.